### PR TITLE
Add clearElements on GuiElementGroup

### DIFF
--- a/src/main/java/de/themoep/inventorygui/GuiElementGroup.java
+++ b/src/main/java/de/themoep/inventorygui/GuiElementGroup.java
@@ -142,11 +142,6 @@ public class GuiElementGroup extends GuiElement {
      * Removes all elements in the group
      */
     public void clearElements() {
-        // Unsure if this is necessary
-        for(GuiElement element : elements) {
-            element.setSlots(new int[0]);
-        }
-
         elements.clear();
     }
     

--- a/src/main/java/de/themoep/inventorygui/GuiElementGroup.java
+++ b/src/main/java/de/themoep/inventorygui/GuiElementGroup.java
@@ -137,6 +137,18 @@ public class GuiElementGroup extends GuiElement {
         }
         return filler;
     }
+
+    /**
+     * Removes all elements in the group
+     */
+    public void clearElements() {
+        // Unsure if this is necessary
+        for(GuiElement element : elements) {
+            element.setSlots(new int[0]);
+        }
+
+        elements.clear();
+    }
     
     /**
      * Set the filler element for empty slots


### PR DESCRIPTION
I'm not sure if this messes up getSlotIndex and similar methods later and if you need to do more stuff, but this seems to work fine in the testing I've done