### PR TITLE
Change URL of repository in README.md to avoid redirects, bump version (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ You can easily depend on the library with maven.
     <dependency>
         <groupId>de.themoep</groupId>
         <artifactId>inventorygui</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
         <scope>compile</scope>
     </dependency>
 </dependencies>

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ You can easily depend on the library with maven.
 ```xml
 <repositories>
     <repository>
-        <id>minebench-repo</id>
-        <url>https://repo.minebench.de/</url>
+        <id>phoenix-repo</id>
+        <url>https://repo.phoenix616.dev/</url>
     </repository>
 </repositories>
 ```

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ You can easily depend on the library with maven.
 ```xml
 <repositories>
     <repository>
-        <id>phoenix-repo</id>
-        <url>https://repo.phoenix616.dev/</url>
+        <id>minebench-repo</id>
+        <url>https://repo.minebench.de/</url>
     </repository>
 </repositories>
 ```

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ You can easily depend on the library with maven.
     <dependency>
         <groupId>de.themoep</groupId>
         <artifactId>inventorygui</artifactId>
+        <!--The following version may not be the latest. Check it before using.-->
         <version>1.4.2-SNAPSHOT</version>
         <scope>compile</scope>
     </dependency>


### PR DESCRIPTION
README.md changelist:
 - Change url from https://repo.minebench.de/ to https://repo.phoenix616.dev/ to avoid redirections which may cause errors when importing using gradle.
 - Bump version from 1.4.1-SNAPSHOT to 1.4.2-SNAPSHOT

Fixes #11 