### PR TITLE
Allows extensive use of inventory (#18)

### DIFF
--- a/src/main/java/de/themoep/inventorygui/InventoryGui.java
+++ b/src/main/java/de/themoep/inventorygui/InventoryGui.java
@@ -777,10 +777,10 @@ public class InventoryGui implements Listener {
     }
     
     /**
-     * Get the inventory. Package scope as it should only be used by InventoryGui.Holder
+     * Get the inventory.
      * @return The GUI's generated inventory
      */
-    Inventory getInventory() {
+    public Inventory getInventory() {
         return getInventory(null);
     }
 
@@ -789,7 +789,7 @@ public class InventoryGui implements Listener {
      * @param who The player, if null it will try to return the inventory created first or null if none was created
      * @return The GUI's generated inventory, null if none was found
      */
-    private Inventory getInventory(HumanEntity who) {
+    public Inventory getInventory(HumanEntity who) {
         return who != null ? inventories.get(who.getUniqueId()) : (inventories.isEmpty() ? null : inventories.values().iterator().next());
     }
 


### PR DESCRIPTION
# Propose to Allow Access to Inventory
The inventory can be extended for devs to handle player inventory events while in InventoryGui created graphical user interfaces if needed.

# Example use
```
   @EventHandler(ignoreCancelled = false, priority = EventPriority.HIGHEST)
    public void onClick(InventoryClickEvent e) {
        // Handles invalid clicks.
        if (e.getSlot() < 0) {
            return;
        }
        // Handles invalid entity.
        if (!(e.getWhoClicked() instanceof Player)) {
            return;
        }
        // Handles empty slot.
        if (e.getCurrentItem() != null && e.getCurrentItem().getType() == (Material.AIR)) {
            return;
        }
        Player player = (Player) e.getWhoClicked();

        if ((InventoryGui.getInventory(player)).equals(e.getInventory())) {
            e.setCancelled(true);
            System.out.println("YOU CLICKED ON THE PLAYER INVENTORY WHILE GUI IS OPEN.");
            // your logics here...
        }
    }
```