### PR TITLE
Allow setting lore without setting display name

### DIFF
--- a/src/main/java/de/themoep/inventorygui/InventoryGui.java
+++ b/src/main/java/de/themoep/inventorygui/InventoryGui.java
@@ -61,7 +61,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
@@ -1219,12 +1218,9 @@ public class InventoryGui implements Listener {
         if (item != null && text != null && text.length > 0) {
             ItemMeta meta = item.getItemMeta();
             if (meta != null) {
-                String combined = replaceVars(player, Arrays.stream(text)
-                        .filter(Objects::nonNull)
-                        .filter(s -> !s.isEmpty())
-                        .collect(Collectors.joining("\n")));
+                String combined = replaceVars(player, Arrays.stream(text).collect(Collectors.joining("\n")));
                 String[] lines = combined.split("\n");
-                meta.setDisplayName(lines[0]);
+                if(text[0] != null) meta.setDisplayName(lines[0]);
                 if (lines.length > 1) {
                     meta.setLore(Arrays.asList(Arrays.copyOfRange(lines, 1, lines.length)));
                 } else {


### PR DESCRIPTION
Fixes #35 
Shouldn't cause any issues. You can assign the first string null and the other strings to anything and only the lore part will be used.