### PR TITLE
Fix GuiStorageElement#getItem not checking set invSlot

### DIFF
--- a/src/main/java/de/themoep/inventorygui/GuiStorageElement.java
+++ b/src/main/java/de/themoep/inventorygui/GuiStorageElement.java
@@ -172,7 +172,7 @@ public class GuiStorageElement extends GuiElement {
     
     @Override
     public ItemStack getItem(HumanEntity who, int slot) {
-        int index = getSlotIndex(slot);
+        int index = getStorageSlot(who, slot);
         if (index > -1 && index < storage.getSize()) {
             return storage.getItem(index);
         }


### PR DESCRIPTION
`GuiStorageElement#getItem` currently ignores the `GuiStorageElement`'s set `invSlot` field. This field needs to be checked because sometimes people will want the storage element to be linked to a specific slot in the backing inventory. Otherwise, the item will always be treated as if `invSlot = -1` which isn't correct.

Was burned on this for almost three hours 🤕