### PR TITLE
InventoryType can also be CREATIVE when there's no gui opened

### DIFF
--- a/src/main/java/de/themoep/inventorygui/InventoryGui.java
+++ b/src/main/java/de/themoep/inventorygui/InventoryGui.java
@@ -575,7 +575,8 @@ public class InventoryGui implements Listener {
     public void show(HumanEntity player, boolean checkOpen) {
         draw(player);
         if (!checkOpen || !this.equals(getOpen(player))) {
-            if (player.getOpenInventory().getType() != InventoryType.CRAFTING) {
+            InventoryType type = player.getOpenInventory().getType();
+            if (type != InventoryType.CRAFTING && type != InventoryType.CREATIVE) {
                 // If the player already has a gui open then we assume that the call was from that gui.
                 // In order to not close it in a InventoryClickEvent listener (which will lead to errors)
                 // we delay the opening for one tick to run after it finished processing the event


### PR DESCRIPTION
The title explained this pull request just perfectly.

In InventoryGui.java, it's only considered that CRAFTING inventory type means no gui is opened, but actually CREATIVE also means that. This fact made this lib works incorrectly under creative mode. For example, in my test, if a player who is in creative mode and haven't opened any gui yet opens a gui twice in one tick, the presented gui appears to act like an empty chest's inventory (i.e. there is no item in it and any operation won't be cancelled) while everything works correctly for a player in survival mode.