### PR TITLE
Don't cancel single slot drag event click

### DIFF
--- a/src/main/java/de/themoep/inventorygui/GuiStorageElement.java
+++ b/src/main/java/de/themoep/inventorygui/GuiStorageElement.java
@@ -108,8 +108,15 @@ public class GuiStorageElement extends GuiElement {
                 return true;
             }
 
+            // Handle single-slot drag like click: validate the final item with PlaceValidator
+            if (click.getRawEvent() instanceof InventoryDragEvent) {
+                InventoryDragEvent drag = (InventoryDragEvent) click.getRawEvent();
+                ItemStack movedItem = drag.getNewItems().get(click.getSlot());
+                return !validateItemPlace(click.getWhoClicked(), click.getSlot(), movedItem);
+            }
+
             if (!(click.getRawEvent() instanceof InventoryClickEvent)) {
-                // Only the click event will be handled here, drag event is handled separately
+                // Only the click event will be handled from here, drag event is handled separately
                 return true;
             }
 


### PR DESCRIPTION
The problem:
When placing an item with a "drag" (the InventoryDragEvent) onto GuiStorageElement, it will always get canceled. Placing a single item with drag event is undistinguishable to a player from a regular inventory click. This creates a weird bug where sometimes item just won't get placed into storage.

This is a fix.